### PR TITLE
print_projects: Resolve symlinks if project.dir() is empty or None

### DIFF
--- a/ecbundle/bundle.py
+++ b/ecbundle/bundle.py
@@ -204,7 +204,12 @@ class BundleCreator(object):
                 continue
             msg = "    - " + project.name()
             if os.path.islink(self.src_dir() + "/" + project.name()):
-                msg += " (symbolic link to [" + project.dir() + "])"
+                if project.dir():
+                    msg += " (symbolic link to [" + project.dir() + "])"
+                else:
+                    msg += " (symbolic link to ["
+                    msg += os.path.realpath(self.src_dir() + "/" + project.name())
+                    msg += "])"
             elif project.version():
                 msg += " (" + project.version() + ")"
             print(msg)

--- a/ecbundle/bundle.py
+++ b/ecbundle/bundle.py
@@ -208,7 +208,7 @@ class BundleCreator(object):
                     msg += " (symbolic link to [" + project.dir() + "])"
                 else:
                     msg += " (symbolic link to ["
-                    msg += os.path.realpath(self.src_dir() + "/" + project.name())
+                    msg += os.readlink(self.src_dir() + "/" + project.name())
                     msg += "])"
             elif project.version():
                 msg += " (" + project.version() + ")"

--- a/tests/bundle_create/test_create.py
+++ b/tests/bundle_create/test_create.py
@@ -143,7 +143,7 @@ def test_create_optional_success(here, cleanup):
     assert (
         "ecbundle_add_project( project2 )" in (src_dir / "CMakeLists.txt").read_text()
     )
-    
+
 
 def test_create_existing_symlink(here, cleanup, watcher):
     """
@@ -168,7 +168,7 @@ def test_create_existing_symlink(here, cleanup, watcher):
     if src_dir.exists():
         shutil.rmtree(src_dir)
     src_dir.mkdir()
-    
+
     # Create a symlink to a fake path in source
     (src_dir / "project1").symlink_to("../non-existent-fake-path")
 

--- a/tests/bundle_create/test_create.py
+++ b/tests/bundle_create/test_create.py
@@ -11,8 +11,14 @@ import shutil
 from pathlib import Path
 
 import pytest
+from conftest import Watcher
 
-from ecbundle import BundleCreator
+from ecbundle import BundleCreator, logger
+
+
+@pytest.fixture
+def watcher():
+    return Watcher(logger=logger)
 
 
 @pytest.fixture
@@ -137,3 +143,39 @@ def test_create_optional_success(here, cleanup):
     assert (
         "ecbundle_add_project( project2 )" in (src_dir / "CMakeLists.txt").read_text()
     )
+    
+
+def test_create_existing_symlink(here, cleanup, watcher):
+    """
+    Test creation of the agglomerated bundle in ``./source`` with a
+    symlink already present.
+    """
+    src_dir = here / "source"
+    args = {
+        "no_colour": True,
+        "verbose": False,
+        "dryrun": True,
+        "dry_run": True,
+        "bundle": "%s" % here,
+        "src_dir": "%s" % src_dir,
+        "update": False,
+        "forced_update": False,
+        "threads": 1,
+        "shallow": False,
+    }
+
+    # Clean directory
+    if src_dir.exists():
+        shutil.rmtree(src_dir)
+    src_dir.mkdir()
+    
+    # Create a symlink to a fake path in source
+    (src_dir / "project1").symlink_to("../non-existent-fake-path")
+
+    with watcher:
+        BundleCreator(**args).create()
+
+    assert (src_dir / "CMakeLists.txt").exists()
+    assert (src_dir / "bundle.yml").exists()
+    assert "- project1" in watcher.output
+    assert "[../non-existent-fake-path]" in watcher.output


### PR DESCRIPTION
I sometimes link an existing working copy of a repository into a bundle's `source` directory and call then `create`, which makes ecbundle skip the clone for that project. I'm aware that this is not necessarily intentional/supported behaviour but it is convenient when the goal is just to test something quickly.

However, `print_projects` at the end fails in that case, because `project.dir()` is `None` if the project wasn't intended to be a link according to the bundle file. This makes the `print_projects` routine a bit more resilient in that regard by looking up the symlink instead of using `project.dir()` if the latter evaluates to `False`.