### PR TITLE
Slurm-aware cpu_count utilty

### DIFF
--- a/ecbundle/util.py
+++ b/ecbundle/util.py
@@ -159,6 +159,15 @@ def cpu_count():
     tasks_per_node = 1
     hyperthreads = 1
 
+    if "SLURM_JOB_ID" in os.environ:
+        slurm_job_id = os.environ["SLURM_JOB_ID"]
+        threads_per_task = execute(f"squeue -j {slurm_job_id} -o %J -h", capture_output=True, silent=True)
+        if threads_per_task.strip() == '*':
+            threads_per_task = 1
+        else:
+            threads_per_task = int(threads_per_task)
+        tasks_per_node = int(execute(f"squeue -j {slurm_job_id} -o %c -h", capture_output=True, silent=True))
+
     if "EC_threads_per_task" in os.environ.keys():
         threads_per_task = int(os.environ["EC_threads_per_task"])
 

--- a/ecbundle/util.py
+++ b/ecbundle/util.py
@@ -166,13 +166,19 @@ def cpu_count():
             # Value is given as part of the environment, including a multiplier `(xN)` with number of nodes `N` for
             # multi-node jobs
             tasks_per_node = os.environ["SLURM_TASKS_PER_NODE"]
-            if '(' in tasks_per_node:
-                tasks_per_node = tasks_per_node[:tasks_per_node.index('(')]
+            if "(" in tasks_per_node:
+                tasks_per_node = tasks_per_node[: tasks_per_node.index("(")]
             tasks_per_node = int(tasks_per_node)
 
         else:
             try:
-                ntpernode = int(execute(f"squeue -j {slurm_job_id} -O ntpernode -h", capture_output=True, silent=True))
+                ntpernode = int(
+                    execute(
+                        f"squeue -j {slurm_job_id} -O ntpernode -h",
+                        capture_output=True,
+                        silent=True,
+                    )
+                )
             except CalledProcessError:
                 # Silently ignore if call to squeue fails
                 ntpernode = 0
@@ -188,7 +194,13 @@ def cpu_count():
             threads_per_task = int(os.environ["SLURM_CPUS_PER_TASK"])
         else:
             try:
-                threads_per_task = int(execute(f"squeue -j {slurm_job_id} -O cpus-per-task -h", capture_output=True, silent=True))
+                threads_per_task = int(
+                    execute(
+                        f"squeue -j {slurm_job_id} -O cpus-per-task -h",
+                        capture_output=True,
+                        silent=True,
+                    )
+                )
             except CalledProcessError:
                 # Silently ignore if call to squeue fails
                 threads_per_task = 1


### PR DESCRIPTION
`cpu_count` tries to guess the number of CPUs available for parallel builds, and this value is then stored in the `build.sh` script and e.g. passed to make via `-j`. This utility routine takes hints from ECMWF-bespoke environment variables `EC_*` to determine correct values, in particular when not having full nodes allocated.

On aa, these variables are not (yet?) available and it will always compile with the fairly large number of cores available. In particular when used within an ecinteractive session, this leads to compilation jobs being killed.

This addition tries to take relevant values from the generic SLURM environment variables `SLURM_TASKS_PER_NODE` and `SLURM_CPUS_PER_TASK`. To make things more complicated, ecinteractive sessions do not provide these values but `squeue` can be queried instead. Naive testing within ecinteractive sessions and for various configurations during job submission gave correct values.