### PR TITLE
Ensure local env.sh is sourced in scripts

### DIFF
--- a/ecbundle/build.py
+++ b/ecbundle/build.py
@@ -225,7 +225,7 @@ fi
 
 exec 1> >(tee -a "$LOG_FILE") 2>&1
 
-source env.sh
+source ./env.sh
 
 set +x
 echo
@@ -274,7 +274,7 @@ fi
 exec 1> >(tee -a "$LOG_FILE") 2>&1
 
 ### Environment
-source env.sh
+source ./env.sh
 
 set +x
 echo


### PR DESCRIPTION
NVHPC's wrapper for MPI compilers are set-up in such a way that they use a common script, which happens to also be available in $PATH. Unfortunately, that script is called `env.sh` and, at least on ac, this somehow takes precedence over the local file. This PR makes sure the local `env.sh` is used in every case.