### PR TITLE
Add https token authentication support

### DIFF
--- a/bin/ecbundle-create
+++ b/bin/ecbundle-create
@@ -67,6 +67,9 @@ def main():
                         help='download shallow git repositories (no history)',
                         action='store_true')
 
+    parser.add_argument('--git-token',
+                        help='Token to be used for git https authentication')
+
     # --------------------------------------------------------------------------
 
     # Close parser and populate variable args

--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -106,6 +106,9 @@ class BundleDownloader(object):
     def src_dir(self):
         return fullpath(self.get("src_dir", "source"))
 
+    def git_token(self):
+        return self.get("git_token")
+
     def bundle(self):
         bundle_path = fullpath(self.get("bundle", None))
         if bundle_path:
@@ -255,8 +258,11 @@ class BundleDownloader(object):
 
                 else:
                     header("Cloning project %s at version %s" % (pkg.name, pkg.version))
+                    clone_url = pkg.url
+                    if self.git_token() and pkg.url.startswith("https://"):
+                        clone_url = pkg.url.replace("https://", f"https://{self.git_token()}@")
                     self.git.clone(
-                        pkg.url,
+                        clone_url,
                         src_dir,
                         pkg.version,
                         pkg.remote,

--- a/tests/bundle_download/bundle_https.yml
+++ b/tests/bundle_download/bundle_https.yml
@@ -1,0 +1,11 @@
+---
+### Bundle
+
+name    : test-bundle-https
+
+projects :
+    - project1 :
+        git     : https://github.com/user/project1.git
+        remote  : ec-user
+        version : 0.0.1
+        bundle  : false

--- a/tests/bundle_download/test_download.py
+++ b/tests/bundle_download/test_download.py
@@ -57,6 +57,7 @@ def args(here):
         "forced_update": False,
         "threads": 1,
         "shallow": False,
+        "git_token": ""
     }
 
 
@@ -277,3 +278,20 @@ def test_download_fail_optional(args, here, watcher):
         in watcher.output
     )
     assert "    - project1" in watcher.output
+
+
+def test_download_https(args, here, watcher):
+    """
+    Simple bundle creation test that git clones a single project using https and token.
+    """
+
+    args["bundle"] = "%s" % (here / "bundle_https.yml")
+    args["git_token"] = "secrettoken"
+
+    with watcher:
+        BundleDownloader(**args).download()
+
+    assert (
+        "git clone -o ec-user https://secrettoken@github.com/user/project1.git" in watcher.output
+    )
+    assert "git -c advice.detachedHead=false checkout 0.0.1" in watcher.output


### PR DESCRIPTION
Adds `--git-token` option to `ecbundle create`. The supplied value is prepended to the repository clone URL.

This will help using ecbundle in GitHub actions CI/CD workflows for bundles as they rely on using tokens to clone repos. 