### PR TITLE
Add git project subdirectories as symlink projects

### DIFF
--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -365,7 +365,7 @@ class BundleDownloader(object):
 
         if len(downloaded_packages) and not dryrun:
             header("\nFollowing projects are checked out in " + self.src_dir() + ":")
-            for (url, version, sha1) in downloaded_packages:
+            for url, version, sha1 in downloaded_packages:
                 print("    - " + url + " (" + version + ")  [" + sha1 + "]")
 
         if len(symlink_projects):

--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -340,6 +340,7 @@ class BundleDownloader(object):
             if project.dir() and (
                 os.path.exists(project.dir())
                 or project.dir() in [p.name for p in git_projects]
+                or os.path.dirname(project.dir()) in [p.name for p in git_projects]
                 or project.dir() in [p.name() for p in symlink_projects]
             ):
                 symlink_projects.append(project)

--- a/tests/bundle_download/bundle_subdir.yml
+++ b/tests/bundle_download/bundle_subdir.yml
@@ -1,0 +1,13 @@
+### Bundle
+
+name    : test-symlink-subdir
+
+projects :
+    - test_project_1 :
+        git     : ${BITBUCKET}/ecsdk/test_project_1
+        version : 0.0.1
+        bundle  : false
+
+    - subdir1 :
+        dir     : test_project_1/subdir1
+        bundle  : false

--- a/tests/bundle_download/test_download.py
+++ b/tests/bundle_download/test_download.py
@@ -277,3 +277,23 @@ def test_download_fail_optional(args, here, watcher):
         in watcher.output
     )
     assert "    - project1" in watcher.output
+
+
+def test_symlink_subdir(args, here, watcher):
+    """
+    Add cloned project subdir as a symlinked bundle entry
+    """
+    args["dry_run"] = False
+    args["dryrun"] = False
+    args["bundle"] = "%s" % (here / "bundle_subdir.yml")
+
+    with watcher:
+        BundleDownloader(**args).download()
+
+    assert (
+        "git clone -o origin ssh://git@git.ecmwf.int/ecsdk/test_project_1"
+        in watcher.output
+    )
+
+    assert ("Following projects are symlinked in") in watcher.output
+    assert "- subdir1 (test_project_1/subdir1)" in watcher.output


### PR DESCRIPTION
To allow greater flexibility in compiling ifs-source components independently, they can be added as symlinked projects to the bundle. This small PR adds this functionality. Once approved and merged, could I please request a tag with this change included.