### PR TITLE
Fix help string for --list-archs

### DIFF
--- a/bin/ecbundle-build
+++ b/bin/ecbundle-build
@@ -71,7 +71,7 @@ def main():
     parser.add_argument('--arch',
                         help='Path to directory containing architecture info')
     parser.add_argument('--list-archs',
-                        help='Path to directory containing architecture info',
+                        help='List the available architectures',
                         action='store_true')
 
     parser.add_argument('--src-dir',


### PR DESCRIPTION
Noticed this when looking at the help message just now.