### PR TITLE
Allow parameterising GitHub urls with GITHUB variable

### DIFF
--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -61,6 +61,7 @@ class GitURL(object):
 
 
 ECMWF_BITBUCKET_URL = "ssh://git@git.ecmwf.int"
+GITHUB_URL = "https://github.com"
 
 
 class BundleDownloader(object):
@@ -152,6 +153,7 @@ class BundleDownloader(object):
                 if project.git():
                     self.url = project.git()
                     self.url = self.url.replace("${BITBUCKET}", ECMWF_BITBUCKET_URL)
+                    self.url = self.url.replace("${GITHUB}", GITHUB_URL)
                 else:
                     error("git not given for package " + self.name)
 

--- a/tests/bundle_download/bundle_github.yml
+++ b/tests/bundle_download/bundle_github.yml
@@ -1,0 +1,10 @@
+---
+### Bundle
+
+name    : test-bundle-https
+
+projects :
+    - project1 :
+        git     : ${GITHUB}/user/project1.git
+        version : 0.0.1
+        bundle  : false


### PR DESCRIPTION
This adds the ability to parameterise URLs to Github repositories using a `${GITHUB}` variable in the same way as for `${BITBUCKET}`. This feature is very handy when switching between protocols (e.g., SSH and HTTPS) without the need to modify the bundle file or hack around in git config for protocol rewrite.

The supplied test verifies that replacement works correctly for both sensible (current) values of using GitHub, as well as when no value is supplied user-side.