### PR TITLE
avoid error when a key is not present in config

### DIFF
--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -79,7 +79,7 @@ class BundleDownloader(object):
                 colors.enable()
 
     def get(self, key, default=None):
-        return self.config[key] if self.config[key] is not None else default
+        return self.config.get(key, default)
 
     def dryrun(self):
         if self.get("dryrun"):


### PR DESCRIPTION
Facing this error with 2.2.0 (not with 2.0.0 used until now) when calling `BundleDonwloader.download()`
without key `github_token` being defined.
This fixes it.

```
  File "/home/gmap/mrpa/destouchesm/.local/lib/python3.10/site-packages/ecbundle/download.py", line 374, in download
    download_projects(git_projects, download_dir)
  File "/home/gmap/mrpa/destouchesm/.local/lib/python3.10/site-packages/ecbundle/download.py", line 305, in download_projects
    errors = pool.map(download_one_project, packages)
  File "/opt/softs/anaconda3/envs/Python310/lib/python3.10/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/opt/softs/anaconda3/envs/Python310/lib/python3.10/multiprocessing/pool.py", line 774, in get
    raise self._value
  File "/opt/softs/anaconda3/envs/Python310/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/softs/anaconda3/envs/Python310/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/gmap/mrpa/destouchesm/.local/lib/python3.10/site-packages/ecbundle/download.py", line 266, in download_one_project
    and self.github_token()
  File "/home/gmap/mrpa/destouchesm/.local/lib/python3.10/site-packages/ecbundle/download.py", line 111, in github_token
    return self.get("github_token")
  File "/home/gmap/mrpa/destouchesm/.local/lib/python3.10/site-packages/ecbundle/download.py", line 82, in get
    return self.config[key] if self.config[key] is not None else default
KeyError: 'github_token'
```

