### PR TITLE
Fix concat with method rather than string

### DIFF
--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -316,7 +316,7 @@ class BundleDownloader(object):
 
         def download_data(data_packages, download_dir):
             for data in data_packages:
-                header("Downloading data " + data.name)
+                header("Downloading data " + data.name())
                 filename = path.basename(data.url())
                 do_download = True
                 if path.exists(download_dir + "/" + filename):


### PR DESCRIPTION
This very small fix allows the use of data category in the bundle