### PR TITLE
Fix edge when target is not absolute path when creating relative symlink

### DIFF
--- a/ecbundle/util.py
+++ b/ecbundle/util.py
@@ -103,8 +103,11 @@ def symlink_force(target, link_name):
     import errno
     import os
 
+    # prefer relative symlink rather than absolute
+    rel_target = os.path.relpath(target, os.path.dirname(link_name))
+
     try:
-        os.symlink(target, link_name)
+        os.symlink(rel_target, link_name)
     except OSError as exc:  # Python >2.5
         if exc.errno == errno.EEXIST:
             os.remove(link_name)

--- a/ecbundle/util.py
+++ b/ecbundle/util.py
@@ -103,11 +103,10 @@ def symlink_force(target, link_name):
     import errno
     import os
 
-    # prefer relative symlink rather than absolute
-    rel_target = os.path.relpath(target, os.path.dirname(link_name))
-
+    if os.path.isabs(target):
+        target = os.path.relpath(target,os.path.dirname(link_name))
     try:
-        os.symlink(rel_target, link_name)
+        os.symlink(target, link_name)
     except OSError as exc:  # Python >2.5
         if exc.errno == errno.EEXIST:
             os.remove(link_name)


### PR DESCRIPTION
This fixes an edge case when target is not absolute path when creating a symlink in the bundle 