### PR TITLE
Only check if project.dir exists after git projects have been downloaded

### DIFF
--- a/ecbundle/build.py
+++ b/ecbundle/build.py
@@ -579,7 +579,9 @@ fi
                     if path.isfile(build_dir + "/" + f):
                         copyfile(build_dir + "/" + f, backup_dir + "/" + f)
                     if path.islink(build_dir + "/" + f):
-                        copyfile(path.realpath(build_dir + "/" + f), backup_dir + "/" + f)
+                        copyfile(
+                            path.realpath(build_dir + "/" + f), backup_dir + "/" + f
+                        )
 
         return backup_dir
 

--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -348,24 +348,9 @@ class BundleDownloader(object):
         header("    " + bundle.file())
 
         for project in bundle.projects():
-            if project.dir() and (
-                os.path.exists(project.dir())
-                or os.path.exists(self.src_dir() + "/" + project.dir())
-                or project.dir() in [p.name for p in git_projects]
-                or os.path.dirname(project.dir()) in [p.name for p in git_projects]
-                or project.dir() in [p.name() for p in symlink_projects]
-                or os.path.dirname(project.dir())
-                in [p.name() for p in symlink_projects]
-            ):
+            if project.dir():
                 symlink_projects.append(project)
             else:
-                if project.dir():
-                    error(
-                        "A directory [%s] is provided for project [%s] but it does not exist."
-                        % (project.dir(), project.name())
-                    )
-                    errcode = 1
-                    continue
                 git_projects.append(GitPackage(project))
 
         for package in bundle.data():
@@ -396,6 +381,17 @@ class BundleDownloader(object):
                     )
                     errcode = 1
                     continue
+
+                if not os.path.exists(project.dir()) and not os.path.exists(
+                    self.src_dir() + "/" + project.dir()
+                ):
+                    error(
+                        "A directory [%s] is provided for project [%s] but it does not exist."
+                        % (project.dir(), project.name())
+                    )
+                    errcode = 1
+                    continue
+
                 symlink_force(project.dir(), linkname)
 
                 print("    - " + project.name() + " (" + project.dir() + ")")


### PR DESCRIPTION
This solves the issue of an example ifs-bundle where ecwam is to be built standalone but it is part of ifs-source/contrib:

```yaml
---
### Bundle

name    : ifs-bundle
version : ***

# <--cut-->

projects :

   # <--cut-->

    - ifs-source :
        git     : ***
        version : ***
        bundle  : false

    - ecwam_dp :
        dir     : ifs-source/contrib/ecwam
        cmake   : >
            ECWAM_DP_ENABLE_SINGLE_PRECISION=OFF

    - ecwam_sp :
        dir     : ifs-source/contrib/ecwam
        cmake   : >
            BUILD_ecwam_sp=OFF
            ECWAM_SP_ENABLE_SINGLE_PRECISION=ON
            ECWAM_SP_OCEANMODEL_HAVE_SINGLE_PRECISION=ON

    - ifs_dp :
        dir     : ifs-source
        cmake   : >
            IFS_DP_ENABLE_SINGLE_PRECISION=OFF
    - ifs_sp :
        dir     : ifs-source
        cmake   : >
            IFS_SP_ENABLE_SINGLE_PRECISION=ON
```

Too strict checks were in place to detect if `dir` was existing at the time of parsing.
Prior to this fix, only `ifs_dp` and `ifs_sp` were OK as `dir` relative to the `${SOURC_DIR}`.
With this fix, also `ecwam_sp` and `ecwam_dp` pointing to internal structure `ifs-source/contrib/ecwam` are suitable.
