### PR TITLE
Feature/quiet fetch pull refs

### DIFF
--- a/ecbundle/git.py
+++ b/ecbundle/git.py
@@ -133,7 +133,9 @@ class Git(object):
                 raise RuntimeError()
         else:
             commands.append(["git", "fetch", "--tags", remote])
-            commands.append(["git", "fetch", remote, "+refs/pull/*:refs/pull/*"])
+            commands.append(
+                ["git", "fetch", "--quiet", remote, "+refs/pull/*:refs/pull/*"]
+            )
 
         for command in commands:
             try:


### PR DESCRIPTION
Silence the output from the command :
`+ git fetch origin +refs/pull/*:refs/pull/*`
```
 * [new ref]             refs/pull/1/head    -> refs/pull/1/head
 * [new ref]             refs/pull/10/head   -> refs/pull/10/head
 * [new ref]             refs/pull/101/head  -> refs/pull/101/head
 * [new ref]             refs/pull/102/head  -> refs/pull/102/head
 * [new ref]             refs/pull/104/head  -> refs/pull/104/head
 * [new ref]             refs/pull/106/head  -> refs/pull/106/head
 * [new ref]             refs/pull/107/head  -> refs/pull/107/head
 * [new ref]             refs/pull/108/head  -> refs/pull/108/head
 * [new ref]             refs/pull/11/head   -> refs/pull/11/head
 * [new ref]             refs/pull/110/head  -> refs/pull/110/head
 * [new ref]             refs/pull/111/head  -> refs/pull/111/head
 * [new ref]             refs/pull/112/head  -> refs/pull/112/head
 * [new ref]             refs/pull/113/head  -> refs/pull/113/head
 * [new ref]             refs/pull/114/head  -> refs/pull/114/head
 * [new ref]             refs/pull/116/head  -> refs/pull/116/head
 * [new ref]             refs/pull/117/head  -> refs/pull/117/head
 * [new ref]             refs/pull/118/head  -> refs/pull/118/head
 * [new ref]             refs/pull/119/head  -> refs/pull/119/head
 * [new ref]             refs/pull/12/head   -> refs/pull/12/head
 * [new ref]             refs/pull/120/head  -> refs/pull/120/head
 * [new ref]             refs/pull/122/head  -> refs/pull/122/head
 * [new ref]             refs/pull/124/head  -> refs/pull/124/head
 * [new ref]             refs/pull/125/head  -> refs/pull/125/head
 * [new ref]             refs/pull/126/head  -> refs/pull/126/head
 * [new ref]             refs/pull/127/head  -> refs/pull/127/head
 * [new ref]             refs/pull/130/head  -> refs/pull/130/head
 ```
 This output was becoming too verbose and unnecessary