### PR TITLE
Apply bundle.yml options in command-line order

### DIFF
--- a/ecbundle/util.py
+++ b/ecbundle/util.py
@@ -99,6 +99,18 @@ def mkdir_p(path):
             raise RuntimeError()
 
 
+def remove_prefix(string, prefix):
+    import re
+
+    return re.sub(r"^{0}".format(prefix), "", string)
+
+
+def remove_suffix(string, suffix):
+    import re
+
+    return re.sub(r"{0}$".format(suffix), "", string)
+
+
 def symlink_force(target, link_name):
     import errno
     import os


### PR DESCRIPTION
### Description

Command line options defined in bundle.yml are always applied in the order they're processed by argparse, i.e. in the order they're defined in the bundle. This means that e.g. if two options `with-foo` and `without-foo` set `BUILD_foo=ON` and `BUILD_foo=OFF` respectively, then both `--with-foo --without-foo` and `--without-foo --with-foo` will produce the same result, which depends only on which option is defined first in bundle.yml. This is an inherent restriction of argparse.

Processing the bundle.yml options (and only the bundle.yml options) in the order they're passed to ecbundle removes this restriction. This doesn't affect all command line options, e.g. arguments passed by `--cmake` will still be processed after any bundle-defined options, but this seems to provide sufficient flexibility for users to be able to obtain the desired result.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 