### PR TITLE
manage multi-remotes

### DIFF
--- a/ecbundle/download.py
+++ b/ecbundle/download.py
@@ -7,9 +7,9 @@
 # does it submit to any jurisdiction.
 
 import re
+from hashlib import md5
 from os import getcwd, makedirs, path
 from subprocess import check_call
-from hashlib import md5
 
 from .bundle import Bundle
 from .data import Data
@@ -169,10 +169,11 @@ class BundleDownloader(object):
 
             def _set_remote(self, project, src_dir=None):
                 from .git import Git
+
                 remote = project.remote(default=None)
                 if remote is None:
                     if src_dir is None or not path.exists(src_dir):
-                        remote = 'origin'
+                        remote = "origin"
                     else:
                         # look for an existing remote with requested url
                         for remote_name, remote_url in Git.remotes(src_dir).items():
@@ -181,7 +182,7 @@ class BundleDownloader(object):
                                 break
                         if remote is None:
                             # not found: use a bijective alias to url
-                            remote = md5(self.url.encode('utf-8')).hexdigest()
+                            remote = md5(self.url.encode("utf-8")).hexdigest()
                 self.remote_str = remote
                 self.remote = self.remote_str.replace("~", "")
 

--- a/ecbundle/git.py
+++ b/ecbundle/git.py
@@ -258,9 +258,13 @@ class Git(object):
     def remotes(src_dir):
         command = ["git", "remote", "-v"]
         try:
-            remotes = execute(command, cwd=src_dir, silent=True, capture_output=True).strip().split('\n')
-            remotes = [l.split() for l in remotes]
-            return {l[0]:l[1] for l in remotes if l[2] == '(fetch)'}
+            remotes = (
+                execute(command, cwd=src_dir, silent=True, capture_output=True)
+                .strip()
+                .split("\n")
+            )
+            remotes = [line.split() for line in remotes]
+            return {line[0]: line[1] for line in remotes if line[2] == "(fetch)"}
         except CalledProcessError:
             raise RuntimeError()
 

--- a/ecbundle/git.py
+++ b/ecbundle/git.py
@@ -254,6 +254,16 @@ class Git(object):
         except CalledProcessError:
             return None
 
+    @staticmethod
+    def remotes(src_dir):
+        command = ["git", "remote", "-v"]
+        try:
+            remotes = execute(command, cwd=src_dir, silent=True, capture_output=True).strip().split('\n')
+            remotes = [l.split() for l in remotes]
+            return {l[0]:l[1] for l in remotes if l[2] == '(fetch)'}
+        except CalledProcessError:
+            raise RuntimeError()
+
     @classmethod
     def is_remote(cls, src_dir, remote, dryrun):
         command = ["git", "ls-remote", remote]

--- a/ecbundle/project.py
+++ b/ecbundle/project.py
@@ -39,7 +39,7 @@ class Project(object):
     def git(self):
         return self.get("git")
 
-    def remote(self, default='origin'):
+    def remote(self, default="origin"):
         return self.get("remote", default)
 
     def submodules(self):

--- a/ecbundle/project.py
+++ b/ecbundle/project.py
@@ -39,8 +39,8 @@ class Project(object):
     def git(self):
         return self.get("git")
 
-    def remote(self):
-        return self.get("remote", "origin")
+    def remote(self, default='origin'):
+        return self.get("remote", default)
 
     def submodules(self):
         return self.get("submodules", False)


### PR DESCRIPTION
### Description

To cope with the issue described in Issue #39, has been implemented the following:

For each git project of the bundle:
* when the remote name is not provided in the bundle, if the repository exists, the registered remotes are explored:
* if a registered remote has the same url as the requested url, its remote name is used
* if no registered remote has the same url, it is added, with a remote name generated uniquely from the url
* the unicity is ensured by hashing the url; it is not very readable, open to any better idea.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 