### PR TITLE
Bundle merge updated

### DIFF
--- a/bin/ecbundle-merge
+++ b/bin/ecbundle-merge
@@ -44,7 +44,7 @@ def main():
                         nargs='+')
 
     
-    parser.add_argument('-o',
+    parser.add_argument('--output','-o',
                         help='output file', default="merged-bundle.yml")
 
     # --------------------------------------------------------------------------

--- a/ecbundle/merge.py
+++ b/ecbundle/merge.py
@@ -34,15 +34,15 @@ class BundleMerger(object):
         if isinstance(original, dict) and isinstance(updates, dict):
             merged = copy.deepcopy(original)
             for key, value in updates.items():
-                if isinstance(value, dict) and value.get("erase",False):
-                    merged.pop(key,None)
+                if isinstance(value, dict) and value.get("erase", False):
+                    merged.pop(key, None)
                     continue
                 if key in merged:
                     if isinstance(merged[key], dict) and isinstance(value, dict):
                         merged[key] = self.deep_merge(merged[key], value)
                     else:
                         merged[key] = copy.deepcopy(value)
-                elif key!="erase":                        
+                elif key != "erase":
                     merged[key] = copy.deepcopy(value)
             return merged
 

--- a/ecbundle/merge.py
+++ b/ecbundle/merge.py
@@ -34,12 +34,15 @@ class BundleMerger(object):
         if isinstance(original, dict) and isinstance(updates, dict):
             merged = copy.deepcopy(original)
             for key, value in updates.items():
+                if isinstance(value, dict) and value.get("erase",False):
+                    merged.pop(key,None)
+                    continue
                 if key in merged:
                     if isinstance(merged[key], dict) and isinstance(value, dict):
                         merged[key] = self.deep_merge(merged[key], value)
                     else:
                         merged[key] = copy.deepcopy(value)
-                else:
+                elif key!="erase":                        
                     merged[key] = copy.deepcopy(value)
             return merged
 

--- a/tests/bundle_merge/bundle-merge-erase.yml
+++ b/tests/bundle_merge/bundle-merge-erase.yml
@@ -1,0 +1,6 @@
+projects :  
+  
+    - project1 :  
+        erase : true
+
+      

--- a/tests/bundle_merge/test_merge.py
+++ b/tests/bundle_merge/test_merge.py
@@ -55,6 +55,20 @@ def test_merge_single_update(here, out_dir):
     assert "updated-branch" in content
 
 
+def test_merge_single_erase(here, out_dir):
+    """Original bundle merged with a single update file."""
+    base = here / "bundle-merge-base.yml"
+    upd = here / "bundle-merge-erase.yml"
+    output = out_dir / "merged.yml"
+
+    rc = BundleMerger(**_args([base, upd], output)).merge()
+
+    assert rc == 0
+    assert output.exists()
+    content = output.read_text()
+    assert "project1" not in content
+
+
 def test_merge_multiple_updates_applied_in_order(here, out_dir):
     """With two updates, the later one wins on conflicting fields."""
     base = here / "bundle-merge-base.yml"


### PR DESCRIPTION
### Description

fixed issue with `-o` argument, (needed to add `--output` so it could be passed into the config object)

added erase feature to erase sections of the bundle. if they have an `erase: true` entry 

for example, to remove eccodes from the bundle, add in the update:


```
    - eccodes :
        erase: true

```

the resulting bundle will no have an eccodes section.

A similar outcome would be possible by setting 

```
    - eccodes :
        dir: ./
        bundle: false

```
but it would pollute the bundle folder with an unnecessary eccodes symlink

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
