### PR TITLE
Allow selection of subdirectory-scoped 'all' targets when using Makefiles

### DIFF
--- a/ecbundle/build.py
+++ b/ecbundle/build.py
@@ -88,8 +88,16 @@ class MakeBackend:
     def file(self):
         return "Makefile"
 
+    def _needs_directory_recursion_file(self, targets):
+        """Return True if any target is a directory-scoped "/all" target."""
+        return any(str(t).endswith("/all") for t in targets)
+
     def command(self, threads, targets, verbose=False, keep_going=False):
-        command_list = [self.executable(), self.threads(threads), self.targets(targets)]
+        command_list = [self.executable(), self.threads(threads)]
+        if self._needs_directory_recursion_file(targets):
+            # "/all" targets only exist in Makefile2, not the top-level Makefile
+            command_list.append("-f CMakeFiles/Makefile2")
+        command_list.append(self.targets(targets))
         if verbose:
             command_list.append(self.verbose())
         if keep_going:

--- a/tests/bundle_build/test_build.py
+++ b/tests/bundle_build/test_build.py
@@ -101,23 +101,9 @@ def _run_build_and_read_script(args, here, watcher):
 
 
 def test_build_make(args, here, cleanup, watcher):
-    src_dir = here / "source"
     build_dir = here / "build"
-    install_dir = here / "install"
 
-    # Clean directory
-    if src_dir.exists():
-        shutil.rmtree(src_dir)
-    if build_dir.exists():
-        shutil.rmtree(build_dir)
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
-
-    src_dir.mkdir()
-    shutil.copy(here / "bundle.yml", src_dir / "bundle.yml")
-
-    with watcher:
-        BundleBuilder(**args).build()
+    build_script = _run_build_and_read_script(args, here, watcher)
 
     # Test that build infrastructure scripts are generated
     # TODO: Check their content is fine!
@@ -134,31 +120,15 @@ def test_build_make(args, here, cleanup, watcher):
     assert ("%s/build.sh --without-configure" % build_dir) in watcher.output
 
     # Ensure that we are calling make
-    with (build_dir / "build.sh").open("r") as f:
-        build_script = f.read()
     assert "make -j1" in build_script
 
 
 def test_build_ninja(args, here, cleanup, watcher):
-    src_dir = here / "source"
     build_dir = here / "build"
-    install_dir = here / "install"
 
     args["ninja"] = True
 
-    # Clean directory
-    if src_dir.exists():
-        shutil.rmtree(src_dir)
-    if build_dir.exists():
-        shutil.rmtree(build_dir)
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
-
-    src_dir.mkdir()
-    shutil.copy(here / "bundle.yml", src_dir / "bundle.yml")
-
-    with watcher:
-        BundleBuilder(**args).build()
+    build_script = _run_build_and_read_script(args, here, watcher)
 
     # Test that build infrastructure scripts are generated
     # TODO: Check their content is fine!
@@ -175,8 +145,6 @@ def test_build_ninja(args, here, cleanup, watcher):
     assert ("%s/build.sh --without-configure" % build_dir) in watcher.output
 
     # Ensure that we are calling make
-    with (build_dir / "build.sh").open("r") as f:
-        build_script = f.read()
     assert "ninja -j1" in build_script
 
 

--- a/tests/bundle_build/test_build.py
+++ b/tests/bundle_build/test_build.py
@@ -74,6 +74,32 @@ def args(here):
     }
 
 
+def _run_build_and_read_script(args, here, watcher):
+    """
+    Clean, configure and build a fresh test bundle with the given args,
+    then return the generated build.sh script's contents.
+    """
+    src_dir = here / "source"
+    build_dir = here / "build"
+    install_dir = here / "install"
+
+    if src_dir.exists():
+        shutil.rmtree(src_dir)
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    if install_dir.exists():
+        shutil.rmtree(install_dir)
+
+    src_dir.mkdir()
+    shutil.copy(here / "bundle.yml", src_dir / "bundle.yml")
+
+    with watcher:
+        BundleBuilder(**args).build()
+
+    with (build_dir / "build.sh").open("r") as f:
+        return f.read()
+
+
 def test_build_make(args, here, cleanup, watcher):
     src_dir = here / "source"
     build_dir = here / "build"
@@ -152,6 +178,71 @@ def test_build_ninja(args, here, cleanup, watcher):
     with (build_dir / "build.sh").open("r") as f:
         build_script = f.read()
     assert "ninja -j1" in build_script
+
+
+def test_build_target_leaf_uses_default_makefile(args, here, cleanup, watcher):
+    """Plain target name builds via the default Makefile, not Makefile2."""
+    args["target"] = ["project1"]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert "make -j1 project1" in build_script
+    assert "Makefile2" not in build_script
+
+
+def test_build_target_directory_scope_uses_makefile2_make(args, here, cleanup, watcher):
+    """ "/all" target is built via Makefile2, not the top-level Makefile."""
+    args["target"] = ["project1/all"]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert "make -j1 -f CMakeFiles/Makefile2 project1/all" in build_script
+
+
+def test_build_target_nested_directory_scope_uses_makefile2_make(
+    args, here, cleanup, watcher
+):
+    """Nested "/all" target is routed through Makefile2."""
+    args["target"] = ["project1/subdir1/all"]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert "make -j1 -f CMakeFiles/Makefile2 project1/subdir1/all" in build_script
+
+
+def test_build_target_mixed_leaf_and_directory_scope_make(args, here, cleanup, watcher):
+    """Plain and "/all" targets can be requested together."""
+    args["target"] = ["project1", "project2/all"]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert "make -j1 -f CMakeFiles/Makefile2 project1 project2/all" in build_script
+
+
+@pytest.mark.parametrize(
+    "pseudo_target", ["install/fast", "install/local", "install/strip"]
+)
+def test_build_target_non_all_pseudo_target_not_rerouted_make(
+    args, here, cleanup, watcher, pseudo_target
+):
+    """Pseudo-targets containing "/" but not ending in "/all" aren't rerouted."""
+    args["target"] = [pseudo_target]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert ("make -j1 %s" % pseudo_target) in build_script
+    assert "Makefile2" not in build_script
+
+
+def test_build_target_directory_scope_ninja(args, here, cleanup, watcher):
+    """Ninja resolves "/all" targets directly, with no rerouting needed."""
+    args["ninja"] = True
+    args["target"] = ["project1/all"]
+
+    build_script = _run_build_and_read_script(args, here, watcher)
+
+    assert "ninja -j1 project1/all" in build_script
+    assert "Makefile2" not in build_script
 
 
 def test_build_custom_arch(args, here, cleanup, watcher):


### PR DESCRIPTION
### Description

CMake gives each new `add_subdirectory()` call its own `all` target, for building everything in that scope. When using the Ninja generator we can select these targets as `--target=foo/all` (`foo/bar/all`, etc.), but when using Makefiles they're defined in CMakeFiles/Makefile2 and not visible to ecbundle. This change adds the relevant Makefile2 targets to the command list, so they can be selected with either generator. Other types of recursive targets (`/clean`, `/install` etc.) remain hidden.

Note that Makefile2 targets don't come with the same `[XX%]` progress counter that Makefile targets do, as they lack the necessary `cmake_progress_start` infrastructure. We could fake this within ecbundle itself, but it'd either be progress against the whole build which isn't especially useful (e.g. it'd stop at 20% instead of 100%), or else we can try to set up counters per subproject, but then it's not clear what's being measured if targets spanning multiple subprojects are selected. So I've left this as is (no counter).

A new helper function is used to streamline the new tests, so the existing build tests have been updated to use it too.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
